### PR TITLE
Rename Firestore locator Query to Filter

### DIFF
--- a/go/internal/genpal/model.go
+++ b/go/internal/genpal/model.go
@@ -17,8 +17,8 @@ type DataNodeProperty struct {
 }
 
 type IndirectField struct {
-	Type         string       `yaml:"type"`
-	FieldName    string       `yaml:"field_name,omitempty"`
-	ExportedName string       `yaml:"exported_name"`
-	Queries      *[]pal.Query `yaml:"queries,omitempty"`
+	Type         string        `yaml:"type"`
+	FieldName    string        `yaml:"field_name,omitempty"`
+	ExportedName string        `yaml:"exported_name"`
+	Queries      *[]pal.Filter `yaml:"queries,omitempty"`
 }

--- a/go/internal/test/chat/privacy.go
+++ b/go/internal/test/chat/privacy.go
@@ -101,7 +101,7 @@ func HandleAccessGroupChat(dataSubjectId string, currentDbObjLocator pal.Locator
 		FirestoreLocator: pal.FirestoreLocator{
 			CollectionPath: append(currentDbObjLocator.FirestoreLocator.CollectionPath, "messages"),
 			DocIDs:         currentDbObjLocator.DocIDs,
-			Queries: []pal.Query{
+			Filters: []pal.Filter{
 				{
 					Path:  "userId",
 					Op:    "==",
@@ -159,7 +159,7 @@ func HandleAccessDirectMessage(dataSubjectId string, currentDbObjLocator pal.Loc
 		FirestoreLocator: pal.FirestoreLocator{
 			CollectionPath: append(currentDbObjLocator.FirestoreLocator.CollectionPath, "messages"),
 			DocIDs:         currentDbObjLocator.DocIDs,
-			Queries: []pal.Query{
+			Filters: []pal.Filter{
 				{
 					Path:  "userId",
 					Op:    "==",

--- a/go/internal/test/chat/privacy_old.go
+++ b/go/internal/test/chat/privacy_old.go
@@ -63,7 +63,7 @@ func (g *GroupChat) HandleAccess(dataSubjectId string, currentDbObjLocator pal.L
 		FirestoreLocator: pal.FirestoreLocator{
 			CollectionPath: append(currentDbObjLocator.FirestoreLocator.CollectionPath, "messages"),
 			DocIDs:         currentDbObjLocator.DocIDs,
-			Queries: []pal.Query{
+			Filters: []pal.Filter{
 				{
 					Path:  "userId",
 					Op:    "==",

--- a/go/pkg/firestore.go
+++ b/go/pkg/firestore.go
@@ -43,10 +43,10 @@ func (c *firestoreClient) getDocuments(loc Locator) ([]DatabaseObject, error) {
 	}
 
 	var query firestore.Query = docRef.Query
-	if len(loc.Queries) > 0 {
-		query = docRef.Where(loc.Queries[0].Path, loc.Queries[0].Op, loc.Queries[0].Value)
-		for i := 1; i < len(loc.Queries); i++ {
-			query = query.Where(loc.Queries[i].Path, loc.Queries[i].Op, loc.Queries[i].Value)
+	if len(loc.Filters) > 0 {
+		query = docRef.Where(loc.Filters[0].Path, loc.Filters[0].Op, loc.Filters[0].Value)
+		for i := 1; i < len(loc.Filters); i++ {
+			query = query.Where(loc.Filters[i].Path, loc.Filters[i].Op, loc.Filters[i].Value)
 		}
 	}
 

--- a/go/pkg/locator.go
+++ b/go/pkg/locator.go
@@ -27,11 +27,11 @@ type FirestoreLocator struct {
 	CollectionPath []string
 	// List of document IDs in the order of collections
 	DocIDs []string
-	// List of queries to be applied to a collection. Ignored if type is document.
-	Queries []Query
+	// List of filters to be applied to a collection. Ignored if type is document.
+	Filters []Filter
 }
 
-type Query struct {
+type Filter struct {
 	Path  string
 	Op    string
 	Value interface{}


### PR DESCRIPTION
The name "Filter" matches that used for MongoDB and the corresponding concept for Firestore in TS.